### PR TITLE
Remove manual assignment of id

### DIFF
--- a/GeorgianMemenator/Network/BusinesssModels/DogBreed.swift
+++ b/GeorgianMemenator/Network/BusinesssModels/DogBreed.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct DogBreed: Identifiable {
-    let id: String = UUID().uuidString
+    let id: String
     let name: String
     let description: String
     let minLife: Int

--- a/GeorgianMemenator/Network/Mappers/DogBreedsMapper.swift
+++ b/GeorgianMemenator/Network/Mappers/DogBreedsMapper.swift
@@ -10,6 +10,7 @@ import Foundation
 enum DogBreedsMapper {
     static func toEntity(dto: DogBreedDTO) -> DogBreed {
         .init(
+            id: dto.id,
             name: dto.attributes.name,
             description: dto.attributes.description,
             minLife: dto.attributes.life.min,


### PR DESCRIPTION
1. I have removed manual assignment of id in DogBreed.
2. I have updated DogBreedsMapper by passing id to DogBreed. 

https://github.com/ashalva/ios.memenator/issues/2